### PR TITLE
Added To-dos, enabled cursors for single userIds, updated how drawing…

### DIFF
--- a/whiteboard-frontend/src/App.css
+++ b/whiteboard-frontend/src/App.css
@@ -5,6 +5,10 @@
   box-sizing: border-box;
 }
 
+/*
+  TO DO: Adjust so sign-in is in the center
+*/
+
 html, body {
   font-family: Arial, sans-serif;
   background-color: #f4f4f9;
@@ -136,8 +140,8 @@ label {
 }
 
 .whiteboard {
-  width: 0.8;
-  height: 0.8;
+  width: 80%;
+  height: 80%;
   background-color: white;
   border: 1px solid #ccc;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1)
@@ -157,4 +161,15 @@ label {
 .eraser-button:hover {
   background-color: #cc0000;
   transform: scale(1.05);
+}
+
+.cursor{
+    position: absolute;
+    color: black;
+    font-weight: bold;
+    padding: 1px 1px;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    font-size: 12px;
+    white-space: nowrap;
 }


### PR DESCRIPTION
…s are sent

Added TO DOs (next steps)

Added labeled cursor for on drawings - Will enable for other users when sockets are more solid

Changed how drawings are sent.

> Previously, whenever a drawing change was made using draw() function, it made a call to the Websocket. I changed this so its only when a user is done drawing. I might make the change back to whenever a drawing it made, or when a implicit number of drawings are made, but for now its only when a drawing is finished. 

