### PR TITLE
Trying to fix Websocket... again

### DIFF
--- a/whiteboard-frontend/src/SignIn.tsx
+++ b/whiteboard-frontend/src/SignIn.tsx
@@ -8,7 +8,6 @@ function SignIn() {
 
   const joinAsGuest = async () => {
     const sessionId = await createConnection();
-    // const connectionId = 
     navigate(`/whiteboard?sessionId=${sessionId}`); // Redirect to the whiteboard page
   };
 

--- a/whiteboard-frontend/src/Whiteboard.tsx
+++ b/whiteboard-frontend/src/Whiteboard.tsx
@@ -14,7 +14,7 @@ const Whiteboard: React.FC = () => {
   const auth = useAuth();
 
   const [sessionId, setSessionId] = useState("0");
-  const [connectionId, setConnectionId] = useState("0");
+  const [userId, setUserId] = useState("0");
 
   // Only run once to handle session ID from URL or localStorage
   useEffect(() => {
@@ -36,19 +36,19 @@ const Whiteboard: React.FC = () => {
   useEffect(() => {
     if (auth.isAuthenticated && auth.user) {
       const cognitoUserId = auth.user.profile.sub || "unknown";
-      setConnectionId(cognitoUserId);
+      setUserId(cognitoUserId);
     } else {
       const random = getRandomNumber(1, 99999999).toString();
-      setConnectionId(random);
+      setUserId(random);
     }
   }, [auth]);
 
   console.log("sessionId from Whiteboard.tsx: " + sessionId);
-  console.log("connectionId from Whiteboard.tsx: " + connectionId);
+  console.log("userId from Whiteboard.tsx: " + userId);
 
   return (
     <div>      
-      <WhiteboardComponent sessionId={sessionId} connectionId={connectionId}></WhiteboardComponent>
+      <WhiteboardComponent sessionId={sessionId} userId={userId}></WhiteboardComponent>
     </div>
   );
 };

--- a/whiteboard-frontend/src/WhiteboardComponent.tsx
+++ b/whiteboard-frontend/src/WhiteboardComponent.tsx
@@ -100,7 +100,7 @@ const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, userId }) =
             sessionId: sessionId,
             userId: userId
         });
-
+        console.log("queryParams: " + queryParams);
         // Connect to WebSocket when the component mounts
         const webSocket = new WebSocket('wss://it1jqs927h.execute-api.us-east-2.amazonaws.com/production?${queryParams.toString()}');
     

--- a/whiteboard-frontend/src/WhiteboardComponent.tsx
+++ b/whiteboard-frontend/src/WhiteboardComponent.tsx
@@ -8,10 +8,10 @@ interface MouseEventWithOffset extends React.MouseEvent<HTMLCanvasElement> {
 }
 interface WhiteboardProps{
     sessionId: string;
-    connectionId: string;
+    userId: string;
 }
 
-const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, connectionId }) => {
+const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, userId }) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
     const [isDrawing, setIsDrawing] = useState<boolean>(false);
@@ -54,13 +54,13 @@ const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, connectionI
         }
         setIsDrawing(false);
 
-        console.log("connectionId from WhiteboardComponent.tsx: " + connectionId);
+        console.log("userId from WhiteboardComponent.tsx: " + userId);
 
         if (ws && path.length > 0) {
             ws.send(JSON.stringify({
                 sessionId,
                 drawingData: {
-                    connectionId,
+                    userId,
                     path,
                     lineWidth,
                     lineColor,
@@ -84,7 +84,7 @@ const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, connectionI
         // Send drawing data over WebSocket
 /*
         TO DO: send collection of drawing events over websocket to parse, instead of each drawing event.
-                Perhaps the path?
+                Perhaps the path? Or evey couple strokes?
 */
     };
     
@@ -95,8 +95,14 @@ const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, connectionI
     const [ws, setWs] = useState<WebSocket | null>(null);
 
     useEffect(() => {
+        // Build query string
+        const queryParams = new URLSearchParams({
+            sessionId: sessionId,
+            userId: userId
+        });
+
         // Connect to WebSocket when the component mounts
-        const webSocket = new WebSocket('wss://it1jqs927h.execute-api.us-east-2.amazonaws.com/production/');
+        const webSocket = new WebSocket('wss://it1jqs927h.execute-api.us-east-2.amazonaws.com/production?${queryParams.toString()}');
     
         webSocket.onopen = () => {
             console.log('WebSocket Connected');
@@ -142,7 +148,7 @@ const WhiteboardComponent: React.FC<WhiteboardProps> = ({ sessionId, connectionI
                             top: `${cursorPosition.y+80}px`, // Adjusting for the offset on canvas - Hard Coded probably should fix
                         }}
                     >
-                        {connectionId}
+                        {userId}
                     </div>
                 )}
             </div>


### PR DESCRIPTION
### Changes made 3-23-2025
> Changed connectionId to userId.

connectionId is a variable that is already in use. When there is a client connection to the Websocket it automatically creates a connectionId as a unique variable to identify the user. Maybe in the future I can use connectionId instead of creating a new variable, but I need a unique identifier to make changes in the frontend. Trying to return the connectionId from the $connect function was troubling and as of right now I'm using userId as the unique identifier.

> Added query params

So, it turns out I was not sending the parameters to the websocket correctly. So, every time I was trying to look into sessions it was defaulting to "global-session" (the default sessionId created in $connect).

.

.

.
Here I am on Gods day... coding. 
Genesis 1:31