### PR TITLE
Storing sessions

### DIFF
--- a/whiteboard-frontend/src/App.css
+++ b/whiteboard-frontend/src/App.css
@@ -192,3 +192,12 @@ label {
     font-size: 12px;
     white-space: nowrap;
 }
+
+.guest-signin-text {
+  padding: 8px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  width: 200px;
+  text-align: center;
+}

--- a/whiteboard-frontend/src/GuestSignIn.tsx
+++ b/whiteboard-frontend/src/GuestSignIn.tsx
@@ -1,0 +1,48 @@
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import "./App.css";
+
+function GuestSignIn() {
+    const navigate = useNavigate();
+    const [guestUsername, setGuestUsername] = useState("");
+    const [sessionId, setSessionId] = useState(""); console.log(sessionId);
+
+    const handleJoin = async () => {
+        if (!guestUsername.trim()) {
+            alert("Please enter a username to continue.");
+            return;
+        }
+    
+        try {
+            const newSessionId = await createConnection();
+            setSessionId(newSessionId); // Updates state
+            navigate(`/whiteboard?sessionId=${newSessionId}&userId=${encodeURIComponent(guestUsername)}`);
+        } catch (error) {
+            alert("Error creating session. Please try again.");
+        }
+    };
+
+    const createConnection = async () => {
+        const response = await fetch("https://qdeqrga8ac.execute-api.us-east-2.amazonaws.com/create-session", {
+        method: "POST",
+        });
+
+        const data = await response.json();
+        return data.sessionId;
+    };
+
+    return (
+        <div className="sign-in-container">
+            <input
+                type="text"
+                className={`guest-signin-text`}
+                placeholder="Enter Username"
+                value={guestUsername}
+                onChange={(e) => setGuestUsername(e.target.value)}
+            />
+            <button onClick={handleJoin}>Join</button>
+        </div>
+    );
+    }
+
+    export default GuestSignIn;

--- a/whiteboard-frontend/src/GuestSignInWithSession.tsx
+++ b/whiteboard-frontend/src/GuestSignInWithSession.tsx
@@ -1,0 +1,61 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import "./App.css";
+
+function GuestSignInWithSession() {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const params = new URLSearchParams(location.search);
+    
+    const [guestUsername, setGuestUsername] = useState("");
+    const [sessionId, setSessionId] = useState(""); console.log(sessionId);
+
+    console.log("Handling Guest Sign In...");
+
+    // Ensure we correctly set sessionId from URL/localStorage before allowing a user to join
+    useEffect(() => {
+        const urlSessionId = params.get("sessionId");
+        const storedSessionId = localStorage.getItem("sessionId");
+
+        if (urlSessionId) {
+            setSessionId(urlSessionId);
+        } else if (storedSessionId) {
+            setSessionId(storedSessionId);
+            localStorage.removeItem("sessionId"); // Clean up after use
+        }
+    }, []); // Only run once on mount
+
+    const handleJoin = async () => {
+        // Use the sessionId from params or localStorage directly instead of relying on state
+        const urlSessionId = params.get("sessionId");
+        const storedSessionId = localStorage.getItem("sessionId");
+        const finalSessionId = urlSessionId || storedSessionId;
+
+        if (!finalSessionId) {
+            alert("Error: No session ID found.");
+            return;
+        }
+        if (!guestUsername.trim()) {
+            alert("Please enter a username to continue.");
+            return;
+        }
+        
+        console.log(`Joining session: ${finalSessionId} as ${guestUsername}`);
+        navigate(`/whiteboard?sessionId=${finalSessionId}&userId=${encodeURIComponent(guestUsername)}`);
+    };
+
+    return (
+        <div className="sign-in-container">
+            <input
+                type="text"
+                className="guest-signin-text"
+                placeholder="Enter Username"
+                value={guestUsername}
+                onChange={(e) => setGuestUsername(e.target.value)}
+            />
+            <button onClick={handleJoin}>Join</button>
+        </div>
+    );
+}
+
+export default GuestSignInWithSession;

--- a/whiteboard-frontend/src/Menu.tsx
+++ b/whiteboard-frontend/src/Menu.tsx
@@ -24,8 +24,8 @@ const Menu: React.FC<MenuProps> = ({ setLineColor, setLineWidth, sessionId, hand
 
     // Function to generate a shareable URL and display the QR code inside the modal
     const handleShareClick = () => {
-        //const shareableUrl = `https://main.d3nwftw9t1phgg.amplifyapp.com/whiteboard?sessionId=${sessionId}`;
-        const shareableUrl = `http://localhost:5173/whiteboard?sessionId=${sessionId}`;
+        const shareableUrl = `https://main.d3nwftw9t1phgg.amplifyapp.com/whiteboard?sessionId=${sessionId}`;
+        //const shareableUrl = `http://localhost:5173/whiteboard?sessionId=${sessionId}`;
         // console.log(sessionId); // This is NOT NULL
         // Construct QR code API URL
         const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(shareableUrl)}`;

--- a/whiteboard-frontend/src/Menu.tsx
+++ b/whiteboard-frontend/src/Menu.tsx
@@ -24,8 +24,9 @@ const Menu: React.FC<MenuProps> = ({ setLineColor, setLineWidth, sessionId, hand
 
     // Function to generate a shareable URL and display the QR code inside the modal
     const handleShareClick = () => {
-        const shareableUrl = `https://main.d3nwftw9t1phgg.amplifyapp.com/whiteboard?sessionId=${sessionId}`;
-        
+        //const shareableUrl = `https://main.d3nwftw9t1phgg.amplifyapp.com/whiteboard?sessionId=${sessionId}`;
+        const shareableUrl = `http://localhost:5173/whiteboard?sessionId=${sessionId}`;
+        // console.log(sessionId); // This is NOT NULL
         // Construct QR code API URL
         const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(shareableUrl)}`;
     

--- a/whiteboard-frontend/src/SignIn.tsx
+++ b/whiteboard-frontend/src/SignIn.tsx
@@ -1,31 +1,16 @@
 import { useNavigate } from "react-router-dom";
-//import { useAuth } from "react-oidc-context";
 import "./App.css";
 
 function SignIn() {
   const navigate = useNavigate();
-  //const auth = useAuth();
 
-  const joinAsGuest = async () => {
-    const sessionId = await createConnection();
-    navigate(`/whiteboard?sessionId=${sessionId}`); // Redirect to the whiteboard page
+  const handleGuestClick = async () => {
+    navigate(`/GuestSignIn`); // Redirect to the Guest Sign in page
   };
 
   const handleSignIn = async () => {
     alert('Sign-in unavailable until later notice.');
-    /*
-    const sessionId = await createConnection();
-    localStorage.setItem("sessionId", sessionId); // Save sessionId for later bc cognito doesn't like query params :(
-    
-    console.log("sessionId: " + sessionId);
-    const redirectUri = encodeURIComponent(
-      "https://main.dbiwmhwrvdu84.amplifyapp.com/whiteboard"
-    );
-    console.log("redirect_uri: " + redirectUri);
-    
-    // Cognito Login URL (no sessionId here)
-    window.location.href = `https://us-east-2sv64gr3vo.auth.us-east-2.amazoncognito.com/login?client_id=1leh5p4ea4vq0imp5nksudclsa&redirect_uri=${redirectUri}&response_type=code&scope=email+openid+phone`;
-    */
+    createConnection(); // TO DO
   };
 
   const createConnection = async () => {
@@ -42,7 +27,7 @@ function SignIn() {
 
   return (
     <div className="sign-in-container">
-      <button onClick={joinAsGuest}>Continue as Guest</button>
+      <button onClick={handleGuestClick}>Continue as Guest</button>
       <button onClick={handleSignIn}>Sign In</button>
     </div>
   );

--- a/whiteboard-frontend/src/Whiteboard.tsx
+++ b/whiteboard-frontend/src/Whiteboard.tsx
@@ -1,54 +1,52 @@
 import React, { useEffect, useState } from "react";
-//import TypingComponent from "./TypingComponent"; // Import TypingComponent
 import WhiteboardComponent from "./WhiteboardComponent";
-import { useLocation } from "react-router-dom";
-import { useAuth } from "react-oidc-context";
-
-const getRandomNumber = (min: number, max: number) => {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-};
+import { useLocation, useNavigate } from "react-router-dom";
 
 const Whiteboard: React.FC = () => {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
-  const auth = useAuth();
+  const navigate = useNavigate();
 
-  const [sessionId, setSessionId] = useState("0");
-  const [userId, setUserId] = useState("0");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
 
-  // Only run once to handle session ID from URL or localStorage
   useEffect(() => {
     const urlSessionId = params.get("sessionId");
+    console.log("URL Session ID:", urlSessionId); // Check if sessionId is being passed correctly
+
     const storedSessionId = localStorage.getItem("sessionId");
+    const urlUserId = params.get("userId");
+    const storedUserId = localStorage.getItem("userId");
 
-    if (urlSessionId) {
-      setSessionId(urlSessionId);
-    } else if (storedSessionId) {
-      setSessionId(storedSessionId);
-      localStorage.removeItem("sessionId"); // Clean up after use
+    // Check if sessionId exists, otherwise redirect to GuestSignInSession
+    if (!urlSessionId && !storedSessionId) {
+        navigate("/GuestSignInSession");
+        return;
     }
-  }, [params]);
 
-  // UseEffect to set guest userId or auth userId
-  /*
-    TO DO: Get this working
-  */
-  useEffect(() => {
-    if (auth.isAuthenticated && auth.user) {
-      const cognitoUserId = auth.user.profile.sub || "unknown";
-      setUserId(cognitoUserId);
-    } else {
-      const random = getRandomNumber(1, 99999999).toString();
-      setUserId(random);
+    if (!urlUserId && !storedUserId) {
+        navigate(`/GuestSignInSession?sessionId=${urlSessionId}`); //This is for when user joins thru url
+        return;
     }
-  }, [auth]);
 
-  //console.log("sessionId from Whiteboard.tsx: " + sessionId);
-  //console.log("userId from Whiteboard.tsx: " + userId);
+    // Set sessionId from URL or localStorage
+    setSessionId(urlSessionId || storedSessionId);
+    localStorage.removeItem("sessionId");
+
+    // Set userId from URL or localStorage
+    setUserId(urlUserId || storedUserId);
+    localStorage.removeItem("userId");
+
+}, [params, navigate]);
+
+  // Prevent rendering if sessionId or userId is not set yet
+  if (!sessionId || !userId) {
+    return <div>Loading...</div>; // Prevents rendering the WhiteboardComponent before redirecting
+  }
 
   return (
-    <div>      
-      <WhiteboardComponent sessionId={sessionId} userId={userId}></WhiteboardComponent>
+    <div>
+      <WhiteboardComponent sessionId={sessionId} userId={userId} />
     </div>
   );
 };

--- a/whiteboard-frontend/src/main.tsx
+++ b/whiteboard-frontend/src/main.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from 'react-oidc-context'; 
 import SignIn from "./SignIn";
 import Whiteboard from "./Whiteboard";
+import GuestSignIn from "./GuestSignIn";
+import GuestSignInWithSession from "./GuestSignInWithSession";
 import './App.css'
 
 const cognitoAuthConfig = {
@@ -23,6 +25,8 @@ ReactDOM.createRoot(container).render(
         <Routes>
           <Route path="/" element={<SignIn />} />
           <Route path="/whiteboard" element={<Whiteboard />} />
+          <Route path="/GuestSignIn" element={<GuestSignIn />} />
+          <Route path="/GuestSignInSession" element={<GuestSignInWithSession />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>


### PR DESCRIPTION
**Guest Sign In**
Guest can now change their name to be more identifiable in the whiteboard. After clicking on _Continue as Guest_ users will be asked for a username and then can press _Join_ to join a session. This works for creating and joining already created sessions. There is not much user handling here. So names can be as long or short (as long as its at least one character) or whatever. 
I wish there was more to say about this because it took me SO many hours.

**Labels are back!**
Labels identifying users appear under where they are drawing. 

**Drawing are Persistent**
Whiteboard are not persistent and saved within a database. This is helpful for when new users are joining a session. Previously if a user had joined a session while there was already drawings on the whiteboard, they would not see all previous drawings before they join. Now, instead of being greeting by a blank whiteboard, they see all previous drawings in the session. It's lovely! This is the next HUGE step for saving and retrieving whiteboards.